### PR TITLE
correct link to f-droid

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ now mainly being developed by members of [Coredump].
 [Coredump]: https://www.coredump.ch/
 
 <a href="https://play.google.com/store/apps/details?id=io.spaceapi.community.myhackerspace"><img width="200" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play"></a>
-<a href="https://f-droid.org/repository/browse/?fdid=ch.fixme.status"><img width="200" src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid"></a>
+<a href="https://f-droid.org/repository/browse/?fdid=io.spaceapi.community.myhackerspace"><img width="200" src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid"></a>
 
 ## How to Compile
 


### PR DESCRIPTION
Once F-Droid has released the new app, it would be good to merge this to get the new link at the f-droid image.