### PR TITLE
add widget and make it more findable

### DIFF
--- a/metadata/en-US/full_description.txt
+++ b/metadata/en-US/full_description.txt
@@ -1,15 +1,16 @@
-<p>View information about hacker- and makerspaces registered in the
+<p>View information about hackerspaces and makerspaces registered in the
 <a href="https://spaceapi.io/">SpaceAPI</a> directory. This includes:</p>
 
 <ul>
     <li>Location and contact information</li>
     <li>Opening status</li>
     <li>Sensor values</li>
+    <li>A widget displaying the current open/closed status on the Android home screen</li>
     <li>...and much more!</li>
 </ul>
 
 <strong>History</strong>
 
-<p>This app was originally developed in 2012 by @rorist from FIXME Lausanne. In
-2021, the app was transferred to the SpaceAPI community repositories and is now
+<p>This app was originally developed in 2012 by @rorist from the FIXME Lausanne hackspace.
+In 2021, the app was transferred to the SpaceAPI community repositories and is now
 mainly being developed by members of Coredump.</p>


### PR DESCRIPTION
- search should hit for 'hackerspace'  'hackspace'
- widget was part of old description and now is part of this one again