### PR TITLE
Reverse latitude and longitude displayed on the screen

### DIFF
--- a/app/src/main/java/io/spaceapi/community/myhackerspace/Main.java
+++ b/app/src/main/java/io/spaceapi/community/myhackerspace/Main.java
@@ -703,7 +703,7 @@ public class Main extends Activity {
 
             // Location
             addTitle(iftr, vg, R.string.api_location);
-            TextView latLonTv = addEntry(iftr, vg, data.location.lon + ", " + data.location.lat);
+            TextView latLonTv = addEntry(iftr, vg, data.location.lat + ", " + data.location.lon);
             Linkify.addLinks(
                 latLonTv,
                 Pattern.compile("^.*$", Pattern.DOTALL),


### PR DESCRIPTION
The app currently formats the coordonates as `longitude, latitude`, I think it should be `latitude, longitude` as it's the more common format.