### PR TITLE
Temporarily use directory from GitHub directly

### DIFF
--- a/app/src/main/java/io/spaceapi/community/myhackerspace/Prefs.java
+++ b/app/src/main/java/io/spaceapi/community/myhackerspace/Prefs.java
@@ -20,7 +20,7 @@ public class Prefs extends PreferenceActivity implements
         OnSharedPreferenceChangeListener {
 
     public static final String KEY_API_ENDPOINT = "api_endpoint";
-    public static final String DEFAULT_API_ENDPOINT = "https://directory.spaceapi.io/";
+    public static final String DEFAULT_API_ENDPOINT = "https://raw.githubusercontent.com/SpaceApi/directory/master/directory.json";
 
     public static final String KEY_API_URL = "apiurl";
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -12,7 +12,7 @@
         android:key="api_endpoint"
         android:title="@string/prefs_api_title"
         android:summary="@string/prefs_api_summary"
-        android:defaultValue="https://directory.spaceapi.io/"
+        android:defaultValue="https://raw.githubusercontent.com/SpaceApi/directory/master/directory.json"
         android:inputType="textUri" />
 
     <EditTextPreference


### PR DESCRIPTION
Tue to a server configuration issue(?), fetching directory.spaceapi.io can currently take quite a long time. Instead, use the directory from GitHub directly, until this is fixed.